### PR TITLE
FEAT: Update color scale in map view

### DIFF
--- a/src/components/Marks.svelte
+++ b/src/components/Marks.svelte
@@ -238,7 +238,12 @@
         const countryData = matchingCountryNames.find(
           (cn) => cn.name === d.properties.LEVEL3_NAM,
         );
-        return countryData ? colorScale(countryData.frequency) : "#ffffff";
+
+        if (matchingCountryNames.length >= 1) {
+          return countryData ? colorScale(countryData.frequency) : "#ffffff26";
+        } else {
+          return "#ffffff";
+        }
       })
       .attr("stroke", "#000")
       .attr("stroke-width", ".5px")


### PR DESCRIPTION
Closes #36 

The map's standard fill color is white. When the user filters, countries that don't have species of the applied filters get a muted, near-transparent green color for clarity.