### PR TITLE
FEAT/FIX: Dynamic sharing part 2

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,14 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" href="/img/brassilogo.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-  		<link rel="stylesheet" href="/fonts/fonts.css" />
-		%sveltekit.head%
-	</head>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/img/brassilogo.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/fonts/fonts.css" />
+    %sveltekit.head%
+  </head>
 
-	<body data-sveltekit-preload-data="hover">
-		<div style="display: contents">%sveltekit.body%</div>
-	</body>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
 </html>

--- a/src/lib/components/FilterSystem.svelte
+++ b/src/lib/components/FilterSystem.svelte
@@ -30,62 +30,6 @@
 
   const categoryStore = createCategoryStore(selectedCategories);
 
-  // Reactive statement to update selectedCategories based on URL query parameters
-  // $: {
-  //   // Directly use $page.url.searchParams to access query parameters
-  //   const queryParams = $page.url.searchParams;
-
-  //   // Loop through all parameter names
-  //   for (const param of queryParams.keys()) {
-  //     // Log the parameter key name (or the category name)
-  //     // console.log(`Parameter Name: ${param}`);
-
-  //     // Log the values for each category
-  //     const paramValue = queryParams.get(param);
-  //     // console.log("the value:", paramValue);
-  //     let appliedFilters = paramValue
-  //       .split(",")
-  //       .map((label) => ({ label, checked: true }));
-  //     // console.log("params verwerkt:", appliedFilters);
-
-  //     let categoryIndex = checkboxStates[`${param}`].items;
-  //     let categoryFilters = categoryIndex.map(
-  //       (categoryFilter) => categoryFilter.value,
-  //     );
-  //     // console.log("THE CAT FILTERS:", categoryFilters);
-
-  //     appliedFilters.forEach((filter) => {
-  //       categoryFilters.filter((item) => {
-  //         if (item === filter.label) {
-  //           categoryIndex.filter((checkbox) => (checkbox.checked = true));
-  //           // console.log(
-  //           //   "what the index looks like after the check:",
-  //           //   categoryIndex,
-  //           // );
-
-  //           // categoryIndex.forEach((checkbox) => {
-  //           //   if (checkbox.value === item) {
-  //           //     checkbox.checked = true; // Keep the checkbox checked if the filter is still applied
-  //           //     console.log(
-  //           //       "what the index looks like after the check:",
-  //           //       categoryIndex,
-  //           //     );
-  //           //   } else {
-  //           //     checkbox.checked = false;
-  //           //   }
-  //         }
-  //         updateTreeVisualization();
-  //       });
-
-  //       // else {
-  //       //   // Remove the filter from queryParams
-  //       //   queryParams.delete(param); // This will cause the page to reload with the updated URL
-  //       //   updateTreeVisualization();
-  //       // }
-  //     });
-  //   }
-  // }
-
   // for searching
   let autocompleteOpen = false;
 
@@ -298,6 +242,7 @@
 
     // Access URL parameters
     const queryParams = $page.url.searchParams;
+    const queryParamsKeys = [...queryParams.keys()];
 
     // Process each parameter
     for (const param of queryParams.keys()) {
@@ -316,23 +261,40 @@
       appliedFilters.forEach((filter) => {
         categoryFilters.forEach((item) => {
           if (item === filter.label) {
-            const checkboxFilter = categoryIndex.find(checkbox => checkbox.value === filter.label);
-
+            const checkboxFilter = categoryIndex.find(
+              (checkbox) => checkbox.value === filter.label,
+            );
             checkboxFilter.checked = true;
-            console.log(checkboxFilter);
           }
         });
       });
+
+      // set etc
+      const indvParam = paramValue.split(",");
+      console.log("The param value:", indvParam);
+
+      let selectedPairing = {
+        cat: category,
+        value: indvParam,
+      };
+
+      const { cat, value } = selectedPairing;
+      if (!selectedCategories[cat]) {
+        selectedCategories[cat] = [];
+        selectedCategories[cat].push(...value);
+        selectedCategories[cat] = [...new Set(selectedCategories[cat])];
+      } else if (!selectedCategories[cat].includes(value)) {
+        selectedCategories[cat].push(value);
+        selectedCategories[cat].push(...value);
+        selectedCategories[cat] = [...new Set(selectedCategories[cat])];
+      }
+
+      console.log("The selected categories are:", selectedCategories);
+      categoryStore.set(selectedCategories);
     }
 
     async function getSelectedSpecies() {
       let selectedSpecies = new Set();
-
-      console.log(
-        "THE RIGHT CHECKBOXSTATE ITEMS:",
-        checkboxStates.societaluse.items,
-      );
-
       Object.entries(checkboxStates).forEach(([category, state]) => {
         state.items.forEach((item) => {
           if (item.checked) {
@@ -358,6 +320,9 @@
       } else {
         d3.select("#clearFilters").style("visibility", "hidden");
       }
+
+      // console.log("The parameter categories are:", queryParamsKeys);
+      console.log("The selected categories are:", selectedCategories);
     }
 
     getSelectedSpecies();
@@ -455,24 +420,6 @@
     updateTreeVisualization();
   }
 
-  // function handleCheckboxChange(category, itemLabel) {
-  //   let item = [category].find((item) => item.label === itemLabel);
-  //   if (item) {
-  //     item.checked = !item.checked;
-  //   }
-
-  //   checkboxStates = {
-  //     ...checkboxStates,
-  //     [category]: {
-  //       ...[category],
-  //       items: [...[category]],
-  //     },
-  //   };
-
-  //   // New logic for filtering and updating the tree
-  //   updateTreeVisualization();
-  // }
-
   function handleCheckboxChange(category, itemLabel, categoryname) {
     let itemsArray = checkboxStates[categoryname].items;
 
@@ -526,17 +473,12 @@
       }
     }
 
-    console.log("Updated selectedItems:", selectedItems);
-    console.log("Updated selectedCategories:", selectedCategories);
-
     // Update the categoryStore with the new selectedCategories
     categoryStore.set(selectedCategories);
 
     // New logic for filtering and updating the tree
     updateTreeVisualization();
   }
-
-  // console.log("CHECKBOXSTATES:", checkboxStates);
 
   function handleGlobalSearchCheckboxChange(item) {
     // Find the item in its original category and update its checked state

--- a/src/lib/components/FilterSystem.svelte
+++ b/src/lib/components/FilterSystem.svelte
@@ -586,6 +586,9 @@
       if ("allSelected" in checkboxStates[category]) {
         checkboxStates[category].allSelected = false;
       }
+
+      selectedCategories = {};
+      categoryStore.set(selectedCategories);
     });
 
     updateTreeVisualization(); // Update the tree visualization

--- a/src/lib/components/FilterSystem.svelte
+++ b/src/lib/components/FilterSystem.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import * as d3 from "d3";
   import { selectedSpeciesStore } from "./store.js";
-  import { createCategoryStore } from "./queryStore";
+  import { createCategoryStore } from "./querystore.js";
   import { writable } from "svelte/store";
   import { page } from "$app/stores";
   import { goto } from "$app/navigation";

--- a/src/lib/components/FilterSystem.svelte
+++ b/src/lib/components/FilterSystem.svelte
@@ -389,7 +389,7 @@
       return items; // Return all items if search term is empty
     }
     return items
-      .filter((item) => item.label.toLowerCase().startsWith(searchTerm))
+      .filter((item) => item.label.toLowerCase().startsWith(searchTerm)) // If we want to also have results that INCLUDE the searchterm, we can change startsWith to includes
       .sort((a, b) => {
         // Sort checked items to the top
         if (a.checked === b.checked) {
@@ -418,7 +418,7 @@
     console.log(allArray);
 
     if (checkboxStates[category].allSelected === true) {
-      console.log(checkboxStates[category].allSelected)
+      console.log(checkboxStates[category].allSelected);
       allArray.forEach((item) => {
         let selectedPairing = {
           cat: category,

--- a/src/lib/components/FilterSystem.svelte
+++ b/src/lib/components/FilterSystem.svelte
@@ -514,15 +514,16 @@
         (checkbox) => checkbox.label === item.label,
       );
 
-      // Find the name of the current category using the mapping
-      categoryName = Object.keys(categoryNames).find(
-        (key) => categoryNames[key] === category,
-      );
+      if (checked.length >= 1) {
+        // Find the name of the current category using the mapping
+        categoryName = Object.keys(categoryNames).find(
+          (key) => categoryNames[key] === category,
+        );
+      }
     });
 
     // Only proceed if the checkbox is checked or found in one or more categories
     if (item.checked || checked.length >= 1) {
-
       let selectedPairing = {
         category: categoryName,
         value: item.value,
@@ -542,12 +543,30 @@
         }
       }
 
-      // Update the categoryStore with the new selectedCategories
-      categoryStore.set(selectedCategories);
-
       // New logic for filtering and updating the tree
       updateTreeVisualization();
+    } else {
+      // Checkbox is unchecked, remove from selectedItems and selectedCategories
+      selectedItems = selectedItems.filter(
+        (select) => select.value !== item.value,
+      );
+
+      checkboxStates[categoryName].items.forEach((checkbox) => {
+        if (checkbox.value === item.value) {
+          checkbox.checked = false;
+        }
+      });
+
+      const categoryValues = selectedCategories[categoryName];
+      if (categoryName) {
+        selectedCategories[categoryName] = categoryValues.filter(
+          (value) => value !== item.value,
+        );
+      }
     }
+
+    // Update the categoryStore with the new selectedCategories
+    categoryStore.set(selectedCategories);
 
     // Trigger reactivity by assigning a new array
     categories.forEach((category) => {

--- a/src/lib/components/FilterSystem.svelte
+++ b/src/lib/components/FilterSystem.svelte
@@ -401,6 +401,7 @@
 
   function toggleSelectAll(category) {
     const allSelected = !checkboxStates[category].allSelected;
+
     checkboxStates = {
       ...checkboxStates,
       [category]: {
@@ -412,6 +413,34 @@
         })),
       },
     };
+
+    const allArray = checkboxStates[category].items.map((item) => item.value);
+    console.log(allArray);
+
+    if (checkboxStates[category].allSelected === true) {
+      console.log(checkboxStates[category].allSelected)
+      allArray.forEach((item) => {
+        let selectedPairing = {
+          cat: category,
+          value: item,
+        };
+
+        const { cat, value } = selectedPairing;
+        if (!selectedCategories[cat]) {
+          selectedCategories[cat] = [];
+          selectedCategories[cat].push(value);
+        } else if (!selectedCategories[cat].includes(value)) {
+          selectedCategories[cat].push(value);
+          selectedCategories[cat] = [...new Set(selectedCategories[cat])];
+        }
+      });
+
+      console.log(selectedCategories);
+    } else {
+      console.log(checkboxStates[category].allSelected);
+      selectedCategories[category] = [];
+    }
+    categoryStore.set(selectedCategories);
 
     updateTreeVisualization();
   }

--- a/src/lib/components/FilterSystem.svelte
+++ b/src/lib/components/FilterSystem.svelte
@@ -306,9 +306,7 @@
         .split(",")
         .map((label) => ({ label, checked: true }));
 
-      // Assuming param is the actual category name and not the parameter name
-      // Adjust this logic based on how your URL parameters are structured
-      const category = param; // This should match the category names defined in checkboxStates
+      const category = param;
 
       let categoryIndex = checkboxStates[category].items;
       let categoryFilters = categoryIndex.map(
@@ -318,14 +316,51 @@
       appliedFilters.forEach((filter) => {
         categoryFilters.forEach((item) => {
           if (item === filter.label) {
-            categoryIndex.forEach((checkbox) => {
-              checkbox.checked = true;
-            });
-            updateTreeVisualization(); // Ensure this is called after all updates
+            const checkboxFilter = categoryIndex.find(checkbox => checkbox.value === filter.label);
+
+            checkboxFilter.checked = true;
+            console.log(checkboxFilter);
           }
         });
       });
     }
+
+    async function getSelectedSpecies() {
+      let selectedSpecies = new Set();
+
+      console.log(
+        "THE RIGHT CHECKBOXSTATE ITEMS:",
+        checkboxStates.societaluse.items,
+      );
+
+      Object.entries(checkboxStates).forEach(([category, state]) => {
+        state.items.forEach((item) => {
+          if (item.checked) {
+            let property = getCategoryProperty(category);
+            let value = item.value || item.label;
+            let matchingItems = metadata.filter((metaItem) => {
+              let dataValue = metaItem[property];
+              return Array.isArray(dataValue)
+                ? dataValue.includes(value)
+                : dataValue === value;
+            });
+            matchingItems.forEach((match) =>
+              selectedSpecies.add(match.SPECIES_NAME_PRINT),
+            );
+          }
+        });
+      });
+
+      await selectedSpeciesStore.set(selectedSpecies);
+
+      if (selectedSpecies.size > 0) {
+        d3.select("#clearFilters").style("visibility", "visible");
+      } else {
+        d3.select("#clearFilters").style("visibility", "hidden");
+      }
+    }
+
+    getSelectedSpecies();
 
     // Call updateTreeVisualization again after processing all params
     updateTreeVisualization();

--- a/src/lib/components/querystore.js
+++ b/src/lib/components/querystore.js
@@ -1,0 +1,48 @@
+import { writable } from "svelte/store";
+import { goto } from "$app/navigation";
+
+export function createCategoryStore(initialCategories) {
+  const { subscribe, set } = writable(initialCategories);
+
+  // Flatten categories into an array of [categoryName, value] pairs
+  function flattenCategories(categories) {
+    return Object.entries(categories).flatMap(([categoryName, values]) => {
+      return values.map((value) => [categoryName, value]);
+    });
+  }
+
+  return {
+    subscribe,
+    set: (categories) => {
+      const flattenedCategories = flattenCategories(categories);
+
+      // Construct query object from flattened categories
+      let query = flattenedCategories.reduce((acc, [key, value]) => {
+        if (!acc[key]) {
+          acc[key] = [];
+        }
+        acc[key].push(value);
+        return acc;
+      }, {});
+
+      // Convert arrays to comma-separated strings
+      for (let key in query) {
+        query[key] = query[key].join(",");
+      }
+
+      // Create URLSearchParams from query object
+      const urlSearchParams = new URLSearchParams(query);
+      const queryString = `?${urlSearchParams.toString()}`;
+
+      // Navigate to new URL with query string
+      goto(queryString, {
+        keepFocus: true,
+        replaceState: true,
+        noScroll: true,
+      });
+
+      // Update store with new categories
+      set(categories);
+    },
+  };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,6 @@
   import Marks from "$lib/components/Marks.svelte";
   import MapLegend from "$lib/components/MapLegend.svelte";
   import Footer from "$lib/components/Footer.svelte";
-   
 
   onMount(async () => {
     const welcomeMessage = d3.select("#welcomeMessage");
@@ -100,8 +99,7 @@
 
 <style>
   body {
-    background: url("/img/sitebackground.jpeg") no-repeat center center
-      fixed;
+    background: url("/img/sitebackground.jpeg") no-repeat center center fixed;
     background-size: cover;
     width: 100%;
     min-height: 100%;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,6 @@
 
     button.on("click", function () {
       welcomeMessage.style("visibility", "hidden");
-      console.log("closing the welcome message");
     });
   });
 
@@ -31,8 +30,6 @@
 
   function toggleView() {
     isFlipped.update((n) => !n);
-    // if (!isFlipped) {
-    // }
   }
 </script>
 

--- a/src/routes/api/hello.js
+++ b/src/routes/api/hello.js
@@ -3,8 +3,8 @@ export async function get() {
   return {
     status: 200,
     body: {
-      message: 'Hello, world!'
-    }
+      message: "Hello, world!",
+    },
   };
 }
 


### PR DESCRIPTION
## Functional Test
1. Run the app via `npm run dev`
2. Filter by checking a few checkboxes, watch the URL and console to see if anything changes (it should)
3. Copy the URL with its parameters, paste in a new tab and visit the site.

The checkboxes are checked; but the tree is in its default state. Also, when you uncheck checkboxes, the URL doesn't update?

## Fixed! 
**Here are the edits you'll find in this PR:**
- [x] When you filter, whether it's with regular checkboxes or using the ones that pop up via the search function, applied filters and their categories get added to the URL as parameters;
- [x] When you remove a filter, it gets removed from the URL as well -> if a category no longer has any filters, its key also gets removed
- [x] When you Clear All Filters, all parameters get removed
- [x] Using the Select All option adds / removes all checkboxes in the relevant category individually (this slots together with the existing function of the Select All automatically detecting how many checkboxes are checked within a category and updating accordingly)
- [x] If you visit the site with URL parameters, the URL gets read; relevant checkboxes get checked and updated in the checkboxStates object; the tree gets updated via the selectedSpecies store. This happens in the onMount so that it's loaded in as an initial state and doesn't cause any issues with reactivity.
