### PR TITLE
FEAT/FIX: Organize PhyloTree-component, add docstrings, fix highlights

### DIFF
--- a/src/lib/components/FilterSystem.svelte
+++ b/src/lib/components/FilterSystem.svelte
@@ -422,8 +422,6 @@
         });
       }
 
-      console.log(selectedSpecies);
-
       if (selectedSpecies.size > 0) {
         d3.select("#clearFilters").style("visibility", "visible");
       } else {
@@ -431,7 +429,6 @@
       }
 
       await selectedSpeciesStore.set(selectedSpecies);
-      console.log("selectedSpecies was set");
     }
 
     // Get selected species based on the initial state

--- a/src/lib/components/FilterSystem.svelte
+++ b/src/lib/components/FilterSystem.svelte
@@ -422,13 +422,16 @@
         });
       }
 
-      await selectedSpeciesStore.set(selectedSpecies);
+      console.log(selectedSpecies);
 
       if (selectedSpecies.size > 0) {
         d3.select("#clearFilters").style("visibility", "visible");
       } else {
         d3.select("#clearFilters").style("visibility", "hidden");
       }
+
+      await selectedSpeciesStore.set(selectedSpecies);
+      console.log("selectedSpecies was set");
     }
 
     // Get selected species based on the initial state
@@ -1001,7 +1004,17 @@
     let selectedSpecies = new Set();
     let anyCheckboxChecked = false;
 
-    // Check if filters are applied and populate selectedSpecies accordingly
+    // Helper function to check if any checkboxes are checked
+    function checkAnyCheckboxesChecked() {
+      Object.entries(checkboxStates).forEach(([category, state]) => {
+        state.items.forEach((item) => {
+          if (item.checked) {
+            anyCheckboxChecked = true;
+          }
+        });
+      });
+    }
+
     if (!unionizeFilters.checked) {
       // Iterate through filter checkboxes and populate selectedSpecies
       Object.entries(checkboxStates).forEach(([category, state]) => {
@@ -1027,18 +1040,10 @@
       selectedSpeciesStore.set(selectedSpecies);
     } else {
       // Check if any checkboxes are checked
-      Object.entries(checkboxStates).forEach(([category, state]) => {
-        state.items.forEach((item) => {
-          if (item.checked) {
-            anyCheckboxChecked = true;
-          }
-        });
-      });
+      checkAnyCheckboxesChecked();
 
       // Apply filters if any checkboxes are checked
       if (anyCheckboxChecked) {
-        d3.select("#clearFilters").style("visibility", "visible");
-
         // Function to apply filters
         function applyFilters(filters, initialData) {
           return filters.reduce((filteredData, filter) => {
@@ -1080,11 +1085,17 @@
 
         selectedSpeciesStore.set(selectedSpecies);
       } else {
-        d3.select("#clearFilters").style("visibility", "hidden");
         selectedSpecies = [];
         selectedSpeciesStore.set(selectedSpecies);
         return; // Exit if no checkboxes are checked
       }
+    }
+
+    // Set visibility of clearFilters button
+    if (anyCheckboxChecked) {
+      d3.select("#clearFilters").style("visibility", "visible");
+    } else {
+      d3.select("#clearFilters").style("visibility", "hidden");
     }
 
     // Set noFilterResults based on the state of selectedSpecies and checkboxes

--- a/src/lib/components/PhyloTree.svelte
+++ b/src/lib/components/PhyloTree.svelte
@@ -911,23 +911,23 @@
            *     TREE EDITS
            *===================**/
 
-          // Change the color of all links and labels to grey
-          svg.selectAll(".link").attr("stroke", "#405f7470");
-          svg.selectAll("text.node").style("fill", "#405f7470");
+          // Make the paths and nodes that aren't being hovered a little less visible
+          svg.selectAll(".link").style("opacity", "0.3");
+          svg.selectAll("text.node").style("opacity", "0.3");
 
           // Now highlight the path and label of the hovered node
           let currentNode = d;
           do {
             d3.select(currentNode.linkNode)
               .attr("stroke", superTribeColor)
+              .style("opacity", "1")
               .raise();
 
             if (!currentNode.children) {
               // If it's a leaf node
-              d3.select(currentNode.data.textNode).style(
-                "fill",
-                superTribeColor,
-              );
+              d3.select(currentNode.data.textNode)
+                .style("fill", superTribeColor)
+                .style("opacity", "1");
             }
 
             currentNode = currentNode.parent;
@@ -939,6 +939,9 @@
           if (!d.children) {
             d3.select(d.data.textNode).style("fill", superTribeColor); // Reset the label color
           }
+
+          svg.selectAll(".link").style("opacity", "1");
+          svg.selectAll("text.node").style("opacity", "1");
 
           // Re-apply the filter settings to the rest of the tree
           updateTreeColors(selectedSpecies);
@@ -1170,7 +1173,7 @@
   /**========================================================================
    *                          COLOR THE NODES AND PATHS
    *                     ACCORDING TO THE RELEVANT SUPERTRIBE
-   * 
+   *
    * Required identifying the relevant supertribe using the sample number and
    * the metadata and then coloring the right nodes and paths based on this.
    *========================================================================**/
@@ -1211,17 +1214,17 @@
 
   /**========================================================================
    *                      UPDATING THE TREE BASED ON FILTERS
-   * 
+   *
    * Using the selected Species (also known as the results of the filtering) to
    * recolor the tree,then finds the right supertribe color if the label is
    * a filter-result or coloring this differently if it isn't.
    *========================================================================**/
 
-   /**
-    * @name updateTreeColors
-    * @role Recolor all paths and nodes in the tree based on filters
-    * @param speciesSet | A set of selected species (species names) to identify the correct paths and nodes
-    */
+  /**
+   * @name updateTreeColors
+   * @role Recolor all paths and nodes in the tree based on filters
+   * @param speciesSet | A set of selected species (species names) to identify the correct paths and nodes
+   */
   function updateTreeColors(speciesSet) {
     sharedRoot.each((node) => {
       // Determine the default color or superTribe color

--- a/src/lib/stores/loadingstore.js
+++ b/src/lib/stores/loadingstore.js
@@ -1,3 +1,3 @@
-import { writable } from 'svelte/store';
+import { writable } from "svelte/store";
 
 export const isLoading = writable(true);


### PR DESCRIPTION
Closes #17 

Organized the entire PhyloTree-component and added docstrings. Then fixed the mouse-over to simply emphasize the hovered path/node-pair instead of dimming all other paths.